### PR TITLE
Fix download relx failure

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -148,28 +148,13 @@ else
 core_native_path = $1
 endif
 
-ifeq ($(shell which wget 2>/dev/null | wc -l), 1)
+ifeq ($(strip $(shell which wget 2>/dev/null | wc -l)), 1)
 define core_http_get
-	wget --no-check-certificate -O $(1) $(2)|| rm $(1)
+	wget --quiet --no-check-certificate -O $(1) $(2)|| rm $(1)
 endef
 else
-define core_http_get.erl
-	ssl:start(),
-	inets:start(),
-	case httpc:request(get, {"$(2)", []}, [{autoredirect, true}], []) of
-		{ok, {{_, 200, _}, _, Body}} ->
-			case file:write_file("$(1)", Body) of
-				ok -> ok;
-				{error, R1} -> halt(R1)
-			end;
-		{error, R2} ->
-			halt(R2)
-	end,
-	halt(0).
-endef
-
 define core_http_get
-	$(call erlang,$(call core_http_get.erl,$(call core_native_path,$1),$2))
+	curl -kLf$(if $(filter-out 0,$(V)),,s)o $(call core_native_path,$1) $2
 endef
 endif
 

--- a/erlang.mk
+++ b/erlang.mk
@@ -2480,7 +2480,7 @@ rel:: relx-rel
 endif
 endif
 
-distclean:: distclean-relx-rel distclean-relx
+distclean:: distclean-relx-rel
 
 # Plugin-specific targets.
 


### PR DESCRIPTION
Using httpc to get release files from github results in 403 error:
`https://github.com/erlang/otp/pull/1859`

This causes downloading of relx failure when building emqx if the relx binary does not exist.

This PR fixes the validation for the existence of `wget`, and then uses `curl` as fallback solution.